### PR TITLE
fix: Disable footer line length check for semantic-release compatibility

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -20,6 +20,7 @@ export default {
     ],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-max-length': [2, 'always', 72],
-    'body-max-line-length': [0]  // Disable body line length check for semantic-release compatibility
+    'body-max-line-length': [0],  // Disable body line length check for semantic-release compatibility
+    'footer-max-line-length': [0]  // Disable footer line length check for semantic-release compatibility
   }
 };


### PR DESCRIPTION
# Pull Request

  ## Description
  Fixes semantic-release failing on main branch due to commitlint rejecting release commit messages with long footers. This was blocking v0.3.0 release after the Code of Conduct PR.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Documentation update
  - [ ] Test improvements
  - [ ] Dependency updates

  ## Related Issues
  Fixes semantic-release CI failure on main branch

  ## Testing
  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] All tests passing locally
  - [x] Manual testing completed

  ## Documentation
  - [ ] README updated (if applicable)
  - [ ] TypeDoc comments added/updated
  - [ ] CHANGELOG.md updated
  - [ ] Breaking changes documented

  ## Quality Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-review of code completed
  - [x] Code passes all linting checks
  - [x] Code passes type checking
  - [x] No console.log statements left in code
  - [x] Performance impact considered
  - [x] Security implications reviewed

  ## Screenshots (if applicable)
  N/A

  ## Additional Notes
  - Semantic-release generates long commit messages with PR links in footers
  - Commitlint was rejecting these with "footer-max-line-length" error
  - This is a critical fix to unblock automated releases
  - Similar to body-max-line-length that was already disabled