### PR TITLE
fix: Use GH_TOKEN for semantic-release authentication

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -112,7 +112,8 @@ jobs:
     - name: Release
       run: npm run release
       env:
-        GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
     name: Deploy Documentation


### PR DESCRIPTION
# Pull Request

  ## Description
  Fixes semantic-release authentication by using GH_TOKEN instead of GITHUB_TOKEN, following official semantic-release documentation for bypassing branch protection rules.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Documentation update
  - [ ] Test improvements
  - [ ] Dependency updates

  ## Related Issues
  Fixes semantic-release failing with protected branch authentication error

  ## Testing
  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] All tests passing locally
  - [x] Manual testing completed

  ## Documentation
  - [ ] README updated (if applicable)
  - [ ] TypeDoc comments added/updated
  - [ ] CHANGELOG.md updated
  - [ ] Breaking changes documented

  ## Quality Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-review of code completed
  - [x] Code passes all linting checks
  - [x] Code passes type checking
  - [x] No console.log statements left in code
  - [x] Performance impact considered
  - [x] Security implications reviewed

  ## Screenshots (if applicable)
  N/A

  ## Additional Notes
  - Based on semantic-release official documentation
  - GH_TOKEN is specifically designed to bypass branch protection
  - GITHUB_TOKEN kept as fallback for other API operations
  - Uses existing SEMANTIC_RELEASE_TOKEN secret configured in repository
  - References: https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#authentication