### PR TITLE
fix: stabilize HealthChecker timing test for CI environments

### DIFF
--- a/tests/unit/monitoring/HealthChecker.unit.test.ts
+++ b/tests/unit/monitoring/HealthChecker.unit.test.ts
@@ -89,7 +89,7 @@ describe('HealthChecker', () => {
 
       const result = await healthChecker.checkAdapterHealth('test-adapter');
 
-      expect(result.responseTime).toBeGreaterThanOrEqual(50);
+      expect(result.responseTime).toBeGreaterThanOrEqual(45); // Allow for timing variance in CI
       expect(result.healthy).toBe(true);
     });
   });


### PR DESCRIPTION
# Pull Request

  ## Description
  Stabilizes the HealthChecker timing test by adjusting the response time expectation from 50ms to 45ms to account for timing variance in CI environments. The test simulates a 50ms delay
  using setTimeout, but actual execution timing can vary slightly due to system load and timer precision, causing occasional flaky test failures.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Documentation update
  - [x] Test improvements
  - [ ] Dependency updates

  ## Related Issues
  Fixes flaky CI test failures in HealthChecker unit tests

  ## Testing
  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] All tests passing locally
  - [x] Manual testing completed

  ## Documentation
  - [ ] README updated (if applicable)
  - [ ] TypeDoc comments added/updated
  - [ ] CHANGELOG.md updated
  - [ ] Breaking changes documented

  ## Quality Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-review of code completed
  - [x] Code passes all linting checks
  - [x] Code passes type checking
  - [x] No console.log statements left in code
  - [x] Performance impact considered
  - [x] Security implications reviewed

  ## Screenshots (if applicable)
  N/A

  ## Additional Notes
  This change addresses intermittent test failures in CI environments where the actual execution time of a simulated 50ms delay can be slightly less due to timer precision and system load. By
   allowing a 5ms tolerance (45ms instead of 50ms), we maintain the test's validity while significantly improving CI stability.