### PR TITLE
docs: update Redis documentation URL to canonical path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-redlock-universal implements distributed Redis locks using the [Redlock algorithm](https://redis.io/docs/manual/patterns/distributed-locks/). It supports both node-redis and ioredis clients through a unified TypeScript API.
+redlock-universal implements distributed Redis locks using the [Redlock algorithm](http://redis.io/topics/distlock). It supports both node-redis and ioredis clients through a unified TypeScript API.
 
 ## Features
 


### PR DESCRIPTION
Update Redlock algorithm documentation link to use the simpler canonical URL format (http://redis.io/topics/distlock) for better consistency with Redis documentation standards.

  Type of Change

  - Bug fix (non-breaking change which fixes an issue)
  - New feature (non-breaking change which adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Performance improvement
  - Code refactoring
  - Documentation update
  - Test improvements
  - Dependency updates

  Related Issues

  N/A

  Testing

  - Unit tests added/updated
  - Integration tests added/updated
  - All tests passing locally
  - Manual testing completed

  Documentation

  - README updated (if applicable)
  - TypeDoc comments added/updated
  - CHANGELOG.md updated
  - Breaking changes documented

  Quality Checklist

  - Code follows the project's style guidelines
  - Self-review of code completed
  - Code passes all linting checks
  - Code passes type checking
  - No console.log statements left in code
  - Performance impact considered
  - Security implications reviewed

  Screenshots (if applicable)

  N/A

  Additional Notes

  This is a minor documentation update to align with Redis's preferred URL format for the Redlock algorithm specification. 