### PR TITLE
docs: add NestJS integration reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![Downloads](https://img.shields.io/npm/dm/redlock-universal.svg)](https://www.npmjs.com/package/redlock-universal)
 
-**Integrations:** [NestJS](https://www.npmjs.com/package/nestjs-redlock-universal)
-
 ## Overview
 
 redlock-universal implements distributed Redis locks using the
 [Redlock algorithm](http://redis.io/topics/distlock). It supports both
 node-redis and ioredis clients through a unified TypeScript API with automatic
 lock extension capabilities.
+
+> **<img src="https://nestjs.com/img/logo-small.svg" width="18" height="18" alt="NestJS" style="vertical-align: middle;"> NestJS Integration:** Check out [nestjs-redlock-universal](https://www.npmjs.com/package/nestjs-redlock-universal) for decorator-based integration with dependency injection.
 
 ## Features
 


### PR DESCRIPTION
## Description
  Add reference to `nestjs-redlock-universal` package in README overview section with NestJS logo for improved ecosystem discoverability.

  ## Type of Change
  - [x] Documentation update

  ## Changes Made
  - Added inline NestJS integration callout in Overview section
  - Includes NestJS logo and link to wrapper package
  - Minimal, non-intrusive placement following industry patterns (TypeORM, Prisma style)

  ## Testing
  - [x] All tests passing locally
  - [x] Pre-commit hooks passed (type-check + lint + tests)

  ## Documentation
  - [x] README updated

  ## Quality Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-review of code completed
  - [x] Code passes all linting checks
  - [x] Code passes type checking

