### PR TITLE
chore: fix scorecard-action version tag (v2 → v2.4.3)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard Analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
# Pull Request

  ## Description
  Fix OpenSSF Scorecard workflow failure — `ossf/scorecard-action` does not publish a floating `v2` tag, only exact version tags. Updated to `v2.4.3` (latest release).

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Documentation update
  - [ ] Test improvements
  - [ ] Dependency updates

  ## Related Issues
  Fixes Scorecard workflow failure introduced in #85

  ## Testing
  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] All tests passing locally
  - [x] Manual testing completed

  ## Documentation
  - [ ] README updated (if applicable)
  - [ ] TypeDoc comments added/updated
  - [ ] CHANGELOG.md updated
  - [ ] Breaking changes documented

  ## Quality Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-review of code completed
  - [x] Code passes all linting checks
  - [x] Code passes type checking
  - [x] No console.log statements left in code
  - [x] Performance impact considered
  - [x] Security implications reviewed