### PR TITLE
chore: resolve lodash security vulnerabilities via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6893,16 +6893,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
   "overrides": {
     "tmp": "^0.2.4",
     "glob": "^10.5.0",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
+    "lodash-es": "^4.18.1",
     "minimatch": ">=9.0.7",
     "handlebars": ">=4.7.9",
     "picomatch": ">=2.3.2",


### PR DESCRIPTION
# Pull Request

  ## Description
  Resolve lodash security vulnerabilities by updating overrides to ^4.18.1 and adding lodash-es override. Fixes CVE-2026-4800 (code injection via `_.template`, CVSS 8.1) and GHSA-f23m-r3pf-42rh (prototype
  pollution via `_.unset`/`_.omit`, CVSS 6.5). Supersedes Dependabot PR #88.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Documentation update
  - [ ] Test improvements
  - [x] Dependency updates

  ## Related Issues
  Supersedes #88
  Resolves Dependabot alerts #51, #52

  ## Testing
  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] All tests passing locally
  - [x] Manual testing completed

  ## Documentation
  - [ ] README updated (if applicable)
  - [ ] TypeDoc comments added/updated
  - [ ] CHANGELOG.md updated
  - [ ] Breaking changes documented

  ## Quality Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-review of code completed
  - [x] Code passes all linting checks
  - [x] Code passes type checking
  - [x] No console.log statements left in code
  - [x] Performance impact considered
  - [x] Security implications reviewed