### PR TITLE
docs: add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: alexpota

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Test Coverage](https://img.shields.io/badge/coverage-86%25-green.svg)](#testing)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![Downloads](https://img.shields.io/npm/dm/redlock-universal.svg)](https://www.npmjs.com/package/redlock-universal)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github)](https://github.com/sponsors/alexpota)
 
 The only distributed lock library supporting **all three** Redis clients:
 


### PR DESCRIPTION
## Summary
  - Add `.github/FUNDING.yml` to enable the GitHub Sponsors button
  - Add sponsor badge to README.md